### PR TITLE
Typo on 02-setting-up-development-environment.mdx

### DIFF
--- a/website/contents/ja/02-setting-up-development-environment.mdx
+++ b/website/contents/ja/02-setting-up-development-environment.mdx
@@ -49,7 +49,7 @@ $ clang -print-targets | grep riscv32
 
 もしGitリポジトリ下で作っていく場合は、次の`.gitignore`をあらかじめ用意しておくと便利です。
 
-```plain:gitignore
+```plain:.gitignore
 /disk/*
 !/disk/.gitkeep
 *.map


### PR DESCRIPTION
ファイル名のドット(.)が抜けていました。